### PR TITLE
Split base image into base-core and base-java and deprecate the monolithic sphonic/base

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,10 @@ each repository name.
 If images should be build for a different organisation than 'sphonic' the env
 variable needs to be change accordingly.
 
-The images are all based on a ubuntu seed image that is created from an ubuntu
-cloud image. A working linux system with docker, lxc-utils and recent
-lxc-templates is required to build the seed image.
+The images are all based on a base-core image which is extending the official
+ubuntu:trusty image.
 
-Ubuntu 14.04 is the system that was used for testing.
-
-The script `ubuntu-seed/build.sh` can be used to generate seed images for
-different ubuntu versions by exporting the `UBUNTU_RELEASE` env variable.
-
-```terminal
-UBUNTU_RELEASE=trusty  ubuntu-seed/build.sh
-UBUNTU_RELEASE=precise ubuntu-seed/build.sh
-```
-
-This will result in `sphonic/ubuntu:trusty` and `sphonic/ubuntu:precise` docker
-images being created and imported.
-
-All other images can be build in a one-shot manner using the supplied helpers:
+The images can be build, removed and published using the following scripts:
 
 ### build_images
 
@@ -55,8 +41,8 @@ the image can be changed to `skip`.*
 
 ### publish_images
 
-This will loop through the defined templates and push the generated images to the
-configured remote docker repository.
+This will loop through the defined templates and push the generated images to
+the configured remote docker repository.
 To successfully push images you have to be authenticated already.
 For authentication with the hub run `docker login` and enter your credentials.
 
@@ -75,7 +61,7 @@ supportive tooling out of the box.
 
 ## Base
 
-A JeOS ubuntu image with some automation around compiler toolkits.
+A JeOS ubuntu image with some automation around compiler and language toolkits.
 
 Included software:
 
@@ -127,15 +113,26 @@ Included software:
 - chromium
 - firefox
 - phantomjs
-- java (openjdk-7)
+- golang (via goenv; no version installed by default)
+- nodejs (via nodenv; no version installed by default)
+- python (via pyenv; no version installed by default)
+- ruby (via rbenv; no version installed by default)
+
+## Base Java
+
+This image extends the Base image by adding java jdk versions and java build
+tools.
+
+Included software:
+
 - ant
 - ivy
 - maven
 - gradle
-- golang (via goenv)
-- nodejs (via nodenv)
-- python (via pyenv)
-- ruby (via rbenv)
+- openjdk-7
+- oracle-jdk-6
+- oracle-jdk-7
+- oracle-jdk-8
 
 ### Builders
 

--- a/_functions.sh
+++ b/_functions.sh
@@ -18,12 +18,12 @@ build() {
   logfile="${LOG_DIR}/${name//:/_}.log"
 
   if [[ ! -d $path ]]; then
-    echo -e "\e[31m ✗ MISSING\e[0m ${DOCKER_USER}/${name}";
+    echo -e "\e[31m ✗ MISSING   \e[0m ${DOCKER_USER}/${name}";
     return
   fi
 
   if [[ ! -r "${path}/${dockerfile}" ]]; then
-    echo -e "\e[31m ✗ MISSING\e[0m ${DOCKER_USER}/${name}/${dockerfile}";
+    echo -e "\e[31m ✗ MISSING   \e[0m ${DOCKER_USER}/${name}/${dockerfile}";
     return
   fi
 
@@ -34,7 +34,7 @@ build() {
   if [[ $ret -gt 0 ]]; then
     # display the last 50 lines for the failed docker build
     tail -n50 $logfile
-    echo -e "\e[31m ✗ FAILURE\e[0m ${DOCKER_USER}/${name}";
+    echo -e "\e[31m ✗ FAILURE   \e[0m ${DOCKER_USER}/${name}";
   else
     # docker doesn't seem to exit with an error code
     # if the Dockerfile fails to create an image.
@@ -44,9 +44,9 @@ build() {
     docker images $repository | grep ${tag} 2>&1 > /dev/null
     if [[ $? -gt 0 ]]; then
       tail -n50 $logfile
-      echo -e "\e[31m ✗ FAILURE\e[0m ${DOCKER_USER}/${name}";
+      echo -e "\e[31m ✗ FAILURE   \e[0m ${DOCKER_USER}/${name}";
     else
-      echo -e "\e[32m ✓ CREATED\e[0m ${DOCKER_USER}/${name}";
+      echo -e "\e[32m ✓ CREATED   \e[0m ${DOCKER_USER}/${name}";
     fi
   fi
 }
@@ -62,12 +62,12 @@ remove() {
     # check if a image with the supplied name is registered
     docker images | grep ${DOCKER_USER}/${name} 2>&1
     if [[ $? -gt 0 ]]; then
-      echo -e "\e[32m ✓ REMOVED\e[0m ${DOCKER_USER}/${name}";
+      echo -e "\e[32m ✓ REMOVED   \e[0m ${DOCKER_USER}/${name}";
     else
-      echo -e "\e[31m ✗ FAILURE\e[0m ${DOCKER_USER}/${name}";
+      echo -e "\e[31m ✗ FAILURE   \e[0m ${DOCKER_USER}/${name}";
     fi
   else
-    echo -e "\e[32m ✓ REMOVED\e[0m ${DOCKER_USER}/${name}";
+    echo -e "\e[32m ✓ REMOVED   \e[0m ${DOCKER_USER}/${name}";
   fi
 }
 
@@ -80,9 +80,9 @@ publish() {
 
   docker push ${DOCKER_USER}/${name} 2>&1 > $logfile
   if [[ $? -gt 0 ]]; then
-    echo -e "\e[31m ✗ FAILURE\e[0m ${DOCKER_USER}/${name}";
+    echo -e "\e[31m ✗ FAILURE   \e[0m ${DOCKER_USER}/${name}";
   else
-    echo -e "\e[32m ✓ PUBLISH\e[0m ${DOCKER_USER}/${name}";
+    echo -e "\e[32m ✓ PUBLISH   \e[0m ${DOCKER_USER}/${name}";
   fi
 }
 
@@ -90,5 +90,12 @@ skip() {
   name=$1;
   path=$2;
 
-  echo -e "\e[33m – SKIPPED\e[0m ${DOCKER_USER}/${name}";
+  echo -e "\e[33m – SKIPPED   \e[0m ${DOCKER_USER}/${name}";
+}
+
+deprecated() {
+  name=$1;
+  path=$2;
+
+  echo -e "\e[34m – DEPRECATED\e[0m ${DOCKER_USER}/${name}";
 }

--- a/build_images
+++ b/build_images
@@ -6,8 +6,14 @@
 source $(dirname $(readlink -f $0))/_functions.sh
 
 # base
-build "base:precise" "builder/base/" "Dockerfile-precise"
-build "base:trusty" "builder/base/" "Dockerfile-trusty"
+deprecated "base:precise" "builder/base/" "Dockerfile-precise"
+deprecated "base:trusty" "builder/base/" "Dockerfile-trusty"
+
+# base-core
+build "base-core:20150219" "builder/base-core/"
+
+# base-java
+build "base-java:20150219" "builder/base-java/"
 
 # gcc
 build "gcc:4.6" "builder/gcc/gcc_4.6/"

--- a/builder/base-core/Dockerfile
+++ b/builder/base-core/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:trusty
+
+MAINTAINER Daniel Malon <operations@sphonic.com>
+
+ADD rootfs/etc /etc/
+ADD rootfs/root /root/
+
+RUN whoami && chown root:root /etc/sudoers && chmod 0440 /etc/sudoers
+
+WORKDIR /root
+USER root
+
+ENV HOME /root
+ENV LOGNAME root
+ENV TERM xterm
+
+ENV LANGUAGE en_US:en
+ENV LANG C
+ENV LC_ALL C
+ENV LC_TYPE C
+
+ADD scripts /tmp/scripts
+RUN cd /tmp && bash scripts/install.sh && sudo rm -rf /tmp/scripts

--- a/builder/base-core/rootfs/etc/apt/apt.conf.d/90forceyes
+++ b/builder/base-core/rootfs/etc/apt/apt.conf.d/90forceyes
@@ -1,0 +1,1 @@
+APT::Get::Assume-Yes "true";APT::Get::force-yes "true";

--- a/builder/base-core/rootfs/etc/bash.bashrc
+++ b/builder/base-core/rootfs/etc/bash.bashrc
@@ -1,0 +1,75 @@
+# System-wide .bashrc file for interactive bash(1) shells.
+
+# To enable the settings / commands in this file for login shells as well,
+# this file has to be sourced in /etc/profile.
+
+# Load default environemnt scripts to be used by the Drone
+# continuous integration system.
+if [ -d /etc/drone.d ]; then
+  for i in /etc/drone.d/*.sh; do
+    if [ -r $i ]; then
+      source $i
+    fi
+  done
+  unset i
+fi
+
+# If not running interactively, don't do anything
+[ -z "$PS1" ] && return
+
+# check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "$debian_chroot" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set a fancy prompt (non-color, overwrite the one in /etc/profile)
+PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+
+# Commented out, don't overwrite xterm -T "title" -n "icontitle" by default.
+# If this is an xterm set the title to user@host:dir
+#case "$TERM" in
+#xterm*|rxvt*)
+#    PROMPT_COMMAND='echo -ne "\033]0;${USER}@${HOSTNAME}: ${PWD}\007"'
+#    ;;
+#*)
+#    ;;
+#esac
+
+# enable bash completion in interactive shells
+#if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
+#    . /etc/bash_completion
+#fi
+
+# sudo hint
+if [ ! -e "$HOME/.sudo_as_admin_successful" ] && [ ! -e "$HOME/.hushlogin" ] ; then
+    case " $(groups) " in *\ admin\ *)
+    if [ -x /usr/bin/sudo ]; then
+	cat <<-EOF
+	To run a command as administrator (user "root"), use "sudo <command>".
+	See "man sudo_root" for details.
+	
+	EOF
+    fi
+    esac
+fi
+
+# if the command-not-found package is installed, use it
+if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-not-found ]; then
+	function command_not_found_handle {
+	        # check because c-n-f could've been removed in the meantime
+                if [ -x /usr/lib/command-not-found ]; then
+		   /usr/bin/python /usr/lib/command-not-found -- "$1"
+                   return $?
+                elif [ -x /usr/share/command-not-found/command-not-found ]; then
+		   /usr/bin/python /usr/share/command-not-found/command-not-found -- "$1"
+                   return $?
+		else
+		   printf "%s: command not found\n" "$1" >&2
+		   return 127
+		fi
+	}
+fi

--- a/builder/base-core/rootfs/etc/drone.d/goenv.sh
+++ b/builder/base-core/rootfs/etc/drone.d/goenv.sh
@@ -1,0 +1,25 @@
+# set default env vars
+export GOENV_VERSION=${GOENV_VERSION:=""}
+
+# extend path
+export PATH=$PATH:~/.goenv/bin
+
+# initialize goenv
+if which goenv > /dev/null; then
+  eval "$(goenv init -)"
+
+  # install requested version if necessary
+  if [[ ! -z ${GOENV_VERSION} ]]; then
+    if [[ -z "$(goenv versions | grep ${GOENV_VERSION})" ]]; then
+      echo "Installing nodejs version: ${GOENV_VERSION}"
+
+      goenv install ${GOENV_VERSION}
+
+      goenv global ${GOENV_VERSION} 1>/dev/null
+      goenv rehash
+    else
+      goenv global ${GOENV_VERSION} 1>/dev/null
+      goenv rehash
+    fi
+  fi
+fi

--- a/builder/base-core/rootfs/etc/drone.d/nodenv.sh
+++ b/builder/base-core/rootfs/etc/drone.d/nodenv.sh
@@ -1,0 +1,26 @@
+# set default env vars
+export NODENV_VERSION=${NODENV_VERSION:=""}
+export NODE_ENV=${NODE_ENV:="test"}
+
+# extend path
+export PATH=$PATH:~/.nodenv/bin
+
+# initialize nodenv
+if which nodenv > /dev/null; then
+  eval "$(nodenv init -)"
+
+  # install requested version if necessary
+  if [[ ! -z ${NODENV_VERSION} ]]; then
+    if [[ -z "$(nodenv versions | grep ${NODENV_VERSION})" ]]; then
+      echo "Installing nodejs version: ${NODENV_VERSION}"
+
+      nodenv install ${NODENV_VERSION}
+
+      nodenv global ${NODENV_VERSION}
+      nodenv rehash
+    else
+      nodenv global ${NODENV_VERSION}
+      nodenv rehash
+    fi
+  fi
+fi

--- a/builder/base-core/rootfs/etc/drone.d/pyenv.sh
+++ b/builder/base-core/rootfs/etc/drone.d/pyenv.sh
@@ -1,0 +1,25 @@
+# set default env vars
+export PYENV_VERSION=${PYENV_VERSION:=""}
+
+# extend path
+export PATH=$PATH:~/.pyenv/bin
+
+# initialize pyenv if needed
+if which pyenv > /dev/null; then
+  eval "$(pyenv init -)"
+
+  # install requested version if necessary
+  if [[ ! -z ${PYENV_VERSION} ]]; then
+    if [[ -z "$(pyenv versions | grep ${PYENV_VERSION})" ]]; then
+      echo "Installing python version: ${PYENV_VERSION}"
+
+      CC=gcc CONFIGURE_OPTS=--enable-shared pyenv install ${PYENV_VERSION}
+
+      pyenv global ${PYENV_VERSION}
+      pyenv rehash
+    else
+      pyenv global ${PYENV_VERSION}
+      pyenv rehash
+    fi
+  fi
+fi

--- a/builder/base-core/rootfs/etc/drone.d/rbenv.sh
+++ b/builder/base-core/rootfs/etc/drone.d/rbenv.sh
@@ -1,0 +1,31 @@
+# set default env vars
+export RBENV_VERSION=${RBENV_VERSION:=""}
+export RAILS_ENV=${RAILS_ENV:="test"}
+
+# extend path
+export PATH=$PATH:~/.rbenv/bin
+
+# initialize rbenv if needed
+if which rbenv > /dev/null; then
+  eval "$(rbenv init -)"
+
+  # install requested version if necessary
+  if [[ ! -z ${RBENV_VERSION} ]]; then
+    if [[ -z "$(rbenv versions | grep ${RBENV_VERSION})" ]]; then
+      echo "Installing ruby version: ${RBENV_VERSION}"
+
+      CC=gcc CONFIGURE_OPTS=--enable-shared rbenv install ${RBENV_VERSION}
+
+      rbenv global ${RBENV_VERSION}
+      rbenv rehash
+
+      # add bundler
+      gem install bundler --no-ri --no-rdoc
+
+      rbenv rehash
+    else
+      rbenv global ${RBENV_VERSION}
+      rbenv rehash
+    fi
+  fi
+fi

--- a/builder/base-core/rootfs/etc/drone.d/xvfb.sh
+++ b/builder/base-core/rootfs/etc/drone.d/xvfb.sh
@@ -1,0 +1,1 @@
+export DISPLAY=:0

--- a/builder/base-core/rootfs/etc/init.d/xvfb
+++ b/builder/base-core/rootfs/etc/init.d/xvfb
@@ -1,0 +1,24 @@
+XVFB=/usr/bin/Xvfb
+XVFBARGS=":99 -ac -screen 0 1024x768x24"
+PIDFILE=/tmp/cucumber_xvfb_99.pid
+case "$1" in
+  start)
+    echo -n "Starting virtual X frame buffer: Xvfb"
+    /sbin/start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile --background --exec $XVFB -- $XVFBARGS
+    echo "."
+    ;;
+  stop)
+    echo -n "Stopping virtual X frame buffer: Xvfb"
+    /sbin/start-stop-daemon --stop --quiet --pidfile $PIDFILE
+    rm -f $PIDFILE
+    echo "."
+    ;;
+  restart)
+    $0 stop
+    $0 start
+    ;;
+  *)
+  echo "Usage: /etc/init.d/xvfb {start|stop|restart}"
+  exit 1
+esac
+exit 0

--- a/builder/base-core/rootfs/etc/resolv.conf
+++ b/builder/base-core/rootfs/etc/resolv.conf
@@ -1,0 +1,4 @@
+nameserver 208.67.222.222
+nameserver 208.67.220.220
+nameserver 8.8.8.8
+nameserver 8.8.4.4

--- a/builder/base-core/rootfs/etc/sudoers
+++ b/builder/base-core/rootfs/etc/sudoers
@@ -1,0 +1,30 @@
+#
+# This file MUST be edited with the 'visudo' command as root.
+#
+# Please consider adding local content in /etc/sudoers.d/ instead of
+# directly modifying this file.
+#
+# See the man page for details on how to write a sudoers file.
+#
+Defaults	env_reset
+Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+# Host alias specification
+
+# User alias specification
+
+# Cmnd alias specification
+
+# User privilege specification
+root	ALL=(ALL:ALL) ALL
+ubuntu  ALL=NOPASSWD: ALL
+
+# Members of the admin group may gain root privileges
+%admin ALL=(ALL) ALL
+
+# Allow members of group sudo to execute any command
+%sudo	ALL=(ALL:ALL) ALL
+
+# See sudoers(5) for more information on "#include" directives:
+
+#includedir /etc/sudoers.d

--- a/builder/base-core/rootfs/root/.gitconfig
+++ b/builder/base-core/rootfs/root/.gitconfig
@@ -1,0 +1,3 @@
+[user]
+  name = drone
+  email = build@drone.io

--- a/builder/base-core/rootfs/root/.ssh/config
+++ b/builder/base-core/rootfs/root/.ssh/config
@@ -1,0 +1,1 @@
+StrictHostKeyChecking no

--- a/builder/base-core/scripts/install-steps/000-build-essential.sh
+++ b/builder/base-core/scripts/install-steps/000-build-essential.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+# install the compiler
+# install suggested/recommended packages
+# install additional build tools
+sudo apt-get -yqq install \
+  gcc \
+  clang \
+  automake \
+  autoconf \
+  autogen \
+  libtool \
+  make \
+  cmake \
+  gdb \
+  bison \
+  flex \
+  build-essential \
+  scons

--- a/builder/base-core/scripts/install-steps/001-libs-essential.sh
+++ b/builder/base-core/scripts/install-steps/001-libs-essential.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -e
+
+# install libcurl
+# install libffi
+# install libfontconfig1
+# install libgdbm
+# install libmagick
+# install libmemcache
+# install libmysql
+# install libncurses
+# install libossp-uuid
+# install libpq
+# install libqt4
+# install libreadline
+# install libsqlite3
+# install libssl
+# install libxml2 + libxslt
+# install libyaml
+# install libz/zlib
+# install libzmq
+sudo apt-get -yqq install \
+  libcurl3 \
+  libcurl3-gnutls \
+  libcurl4-openssl-dev \
+  libffi-dev \
+  libffi6 \
+  libfontconfig1-dev \
+  libgdbm-dev \
+  libgvc6 \
+  libmagickwand-dev \
+  imagemagick \
+  libmemcache-dev \
+  libmysqlclient-dev \
+  libncurses5 \
+  libncurses5-dev \
+  libncurses5-dbg \
+  libossp-uuid-dev \
+  libpq-dev \
+  libqt4-dev \
+  libreadline6 \
+  libreadline6-dev \
+  libsqlite3-dev \
+  sqlite3 \
+  sqlite3-doc \
+  libssl-dev \
+  libxml2-dev \
+  libxslt1-dev \
+  libxslt-dev \
+  libyaml-0-2 \
+  libyaml-dev \
+  zlib1g \
+  zlib1g-dev \
+  libzmq-dev

--- a/builder/base-core/scripts/install-steps/020-cli-mysql.sh
+++ b/builder/base-core/scripts/install-steps/020-cli-mysql.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+# install mysql-client
+sudo apt-get install -yqq \
+  mysql-client

--- a/builder/base-core/scripts/install-steps/020-cli-postgres.sh
+++ b/builder/base-core/scripts/install-steps/020-cli-postgres.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+# install postgresql-client
+sudo apt-get install -yqq \
+  postgresql-client

--- a/builder/base-core/scripts/install-steps/030-browser-chromedriver.sh
+++ b/builder/base-core/scripts/install-steps/030-browser-chromedriver.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+CHROMEDRIVER_VERSION=${CHROMEDRIVER_VERSION:="2.14"}
+
+pushd /tmp
+
+# download and extract binary package
+curl -Lo chromedriver.zip http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip
+unzip chromedriver.zip
+
+# install binary
+sudo install -t /usr/local/bin chromedriver
+
+# cleanup
+rm -rf chromedriver*
+
+popd

--- a/builder/base-core/scripts/install-steps/030-browser-chromium.sh
+++ b/builder/base-core/scripts/install-steps/030-browser-chromium.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+# install libqtwebkit + chromium
+sudo apt-get install -yqq \
+  libqtwebkit-dev \
+  chromium-browser

--- a/builder/base-core/scripts/install-steps/030-browser-firefox.sh
+++ b/builder/base-core/scripts/install-steps/030-browser-firefox.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+# install firefox
+sudo apt-get install -yqq \
+  firefox

--- a/builder/base-core/scripts/install-steps/030-browser-phantomjs.sh
+++ b/builder/base-core/scripts/install-steps/030-browser-phantomjs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+PHANTOMJS_VERSION=${PHANTOMJS_VERSION:="1.9.2"}
+
+pushd /tmp
+
+# download and extract binary package
+curl -L https://phantomjs.googlecode.com/files/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 | tar -xj
+
+# install binary
+sudo install -t /usr/local/bin phantomjs-${PHANTOMJS_VERSION}-linux-x86_64/bin/phantomjs
+
+# cleanup
+rm -rf phantomjs-${PHANTOMJS_VERSION}-linux-x86_64*
+
+popd

--- a/builder/base-core/scripts/install-steps/040-lang-golang.sh
+++ b/builder/base-core/scripts/install-steps/040-lang-golang.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+# clone goenv
+# use the Sphonic/goenv fork because of changes for binary download URLs
+sudo git clone git://github.com/Sphonic/goenv.git ~/.goenv
+
+# alter path and install default golang via /etc/drone.d/goenv.sh
+sudo bash /etc/drone.d/goenv.sh

--- a/builder/base-core/scripts/install-steps/040-lang-nodejs.sh
+++ b/builder/base-core/scripts/install-steps/040-lang-nodejs.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+# clone nodenv
+sudo git clone git://github.com/OiNutter/nodenv.git ~/.nodenv
+sudo git clone git://github.com/OiNutter/node-build.git ~/.nodenv/plugins/node-build
+
+# alter path and install default nodejs via /etc/drone.d/nodenv.sh
+sudo bash /etc/drone.d/nodenv.sh

--- a/builder/base-core/scripts/install-steps/040-lang-python.sh
+++ b/builder/base-core/scripts/install-steps/040-lang-python.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+# clone pyenv
+sudo git clone git://github.com/yyuu/pyenv.git ~/.pyenv
+
+# alter path and install default python via /etc/drone.d/pyenv.sh
+sudo bash /etc/drone.d/pyenv.sh

--- a/builder/base-core/scripts/install-steps/040-lang-ruby.sh
+++ b/builder/base-core/scripts/install-steps/040-lang-ruby.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+# clone rbenv + ruby-build
+sudo git clone git://github.com/sstephenson/rbenv.git ~/.rbenv
+sudo git clone git://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
+
+# alter path and install default ruby via /etc/drone.d/rbenv.sh
+sudo bash /etc/drone.d/rbenv.sh

--- a/builder/base-core/scripts/install.sh
+++ b/builder/base-core/scripts/install.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# reconfigure debconf to be noninteactive
+echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# update package repository cache
+sudo apt-get -yqq update
+
+# add essential packages
+sudo apt-get install -yqq \
+  software-properties-common \
+  git git-core \
+  subversion \
+  mercurial \
+  bzr \
+  fossil \
+  xvfb \
+  socat \
+  unzip xzdec \
+  curl wget
+
+# loop over available install steps and execute them one-by-one
+# naming defines order of execution
+for step in $(dirname $(readlink -f $0))/install-steps/*.sh; do
+  if [[ -x $step ]]; then
+    source $step
+  fi
+done
+
+# cleanup
+sudo apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# exit successfully
+exit 0

--- a/builder/base-java/Dockerfile
+++ b/builder/base-java/Dockerfile
@@ -1,0 +1,6 @@
+FROM sphonic/base-core:20150219
+
+MAINTAINER Daniel Malon <operations@sphonic.com>
+
+ADD scripts /tmp/scripts
+RUN cd /tmp && bash scripts/install.sh && sudo rm -rf /tmp/scripts

--- a/builder/base-java/scripts/install.sh
+++ b/builder/base-java/scripts/install.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# accept licenses for oracle-java
+cat << EOF | sudo /usr/bin/debconf-set-selections
+oracle-java6-installer shared/accepted-oracle-license-v1-1 select true
+oracle-java7-installer shared/accepted-oracle-license-v1-1 select true
+oracle-java8-installer shared/accepted-oracle-license-v1-1 select true
+EOF
+
+# add oracle-java installer ppa repository
+sudo add-apt-repository -y ppa:webupd8team/java
+
+# update package repository cache
+sudo apt-get -yqq update
+
+# install oracle-jdk-6
+# install oracle-jdk-7
+# install oracle-jdk-8
+# install openjdk-7
+sudo apt-get install -yqq \
+  oracle-java6-installer \
+  oracle-java7-installer \
+  oracle-java8-installer \
+  openjdk-7-jdk
+
+# set openjdk-7 as default jdk
+sudo update-java-alternatives -s java-1.7.0-openjdk-amd64
+
+# install java buildtools
+sudo apt-get install -yqq \
+  ant \
+  ant-contrib \
+  ivy \
+  maven
+
+# install gradle
+GRADLE_VERSION=${GRADLE_VERSION:="2.2.1"}
+
+pushd /tmp
+
+# download and extract binary package
+curl -Lo gradle.zip https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip
+unzip gradle.zip
+
+# move to /usr/local and symlink executable
+sudo mv gradle-${GRADLE_VERSION} /usr/local/gradle-${GRADLE_VERSION}
+sudo chown -R root:root /usr/local/gradle-${GRADLE_VERSION}
+sudo ln -sf /usr/local/gradle-${GRADLE_VERSION}/bin/gradle /usr/local/bin/gradle
+
+popd
+
+# cleanup
+sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/oracle-jdk*-installer
+
+# exit successfully
+exit 0

--- a/builder/clojure/leiningen_2.5.1/Dockerfile
+++ b/builder/clojure/leiningen_2.5.1/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-java:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ADD https://raw.githubusercontent.com/technomancy/leiningen/2.5.1/bin/lein /usr/local/bin/lein
 

--- a/builder/gcc/gcc_4.6/Dockerfile
+++ b/builder/gcc/gcc_4.6/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 RUN \
   add-apt-repository --yes ppa:jon-severinsson/ffmpeg   && \

--- a/builder/gcc/gcc_4.7/Dockerfile
+++ b/builder/gcc/gcc_4.7/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 RUN \
   add-apt-repository --yes ppa:jon-severinsson/ffmpeg   && \

--- a/builder/gcc/gcc_4.8/Dockerfile
+++ b/builder/gcc/gcc_4.8/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 RUN \
   add-apt-repository --yes ppa:jon-severinsson/ffmpeg   && \

--- a/builder/golang/golang_1.2.2/Dockerfile
+++ b/builder/golang/golang_1.2.2/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ENV GOENV_VERSION 1.2.2
 

--- a/builder/golang/golang_1.3.3/Dockerfile
+++ b/builder/golang/golang_1.3.3/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ENV GOENV_VERSION 1.3.3
 

--- a/builder/golang/golang_1.4.1/Dockerfile
+++ b/builder/golang/golang_1.4.1/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ENV GOENV_VERSION 1.4.1
 

--- a/builder/nodejs/nodejs_0.10.36/Dockerfile
+++ b/builder/nodejs/nodejs_0.10.36/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ENV NODENV_VERSION 0.10.36
 

--- a/builder/nodejs/nodejs_0.11.14/Dockerfile
+++ b/builder/nodejs/nodejs_0.11.14/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ENV NODENV_VERSION 0.11.14
 

--- a/builder/nodejs/nodejs_0.8.26/Dockerfile
+++ b/builder/nodejs/nodejs_0.8.26/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ENV NODENV_VERSION 0.8.26
 

--- a/builder/python/python_2.7.9/Dockerfile
+++ b/builder/python/python_2.7.9/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ENV PYENV_VERSION 2.7.9
 

--- a/builder/python/python_3.2.6/Dockerfile
+++ b/builder/python/python_3.2.6/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ENV PYENV_VERSION 3.2.6
 

--- a/builder/python/python_3.3.6/Dockerfile
+++ b/builder/python/python_3.3.6/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ENV PYENV_VERSION 3.3.6
 

--- a/builder/python/python_3.4.2/Dockerfile
+++ b/builder/python/python_3.4.2/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ENV PYENV_VERSION 3.4.2
 

--- a/builder/ruby/ruby_1.9.3-p551/Dockerfile
+++ b/builder/ruby/ruby_1.9.3-p551/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ENV RBENV_VERSION 1.9.3-p551
 

--- a/builder/ruby/ruby_2.0.0-p598/Dockerfile
+++ b/builder/ruby/ruby_2.0.0-p598/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ENV RBENV_VERSION 2.0.0-p598
 

--- a/builder/ruby/ruby_2.1.5/Dockerfile
+++ b/builder/ruby/ruby_2.1.5/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ENV RBENV_VERSION 2.1.5
 

--- a/builder/ruby/ruby_2.2.0/Dockerfile
+++ b/builder/ruby/ruby_2.2.0/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-core:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ENV RBENV_VERSION 2.2.0
 

--- a/builder/scala/scala_2.10.4/Dockerfile
+++ b/builder/scala/scala_2.10.4/Dockerfile
@@ -6,7 +6,9 @@ ADD http://www.scala-lang.org/files/archive/scala-2.10.4.deb /tmp/
 ADD http://repo.scala-sbt.org/scalasbt/sbt-native-packages/org/scala-sbt/sbt/0.13.1/sbt.deb /tmp/
 
 RUN \
+  apt-get update -qq                                                          && \
   apt-get install libjansi-java libjansi-native-java libhawtjni-runtime-java  && \
   dpkg -i /tmp/scala-2.10.4.deb                                               && \
   dpkg -i /tmp/sbt.deb                                                        && \
-  rm -f /tmp/scala-2.10.4.deb /tmp/sbt.deb
+  apt-get clean                                                               && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/builder/scala/scala_2.10.4/Dockerfile
+++ b/builder/scala/scala_2.10.4/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-java:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ADD http://www.scala-lang.org/files/archive/scala-2.10.4.deb /tmp/
 ADD http://repo.scala-sbt.org/scalasbt/sbt-native-packages/org/scala-sbt/sbt/0.13.1/sbt.deb /tmp/

--- a/builder/scala/scala_2.11.5/Dockerfile
+++ b/builder/scala/scala_2.11.5/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-java:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ADD http://www.scala-lang.org/files/archive/scala-2.11.5.deb /tmp/
 ADD http://repo.scala-sbt.org/scalasbt/sbt-native-packages/org/scala-sbt/sbt/0.13.1/sbt.deb /tmp/

--- a/builder/scala/scala_2.11.5/Dockerfile
+++ b/builder/scala/scala_2.11.5/Dockerfile
@@ -6,7 +6,9 @@ ADD http://www.scala-lang.org/files/archive/scala-2.11.5.deb /tmp/
 ADD http://repo.scala-sbt.org/scalasbt/sbt-native-packages/org/scala-sbt/sbt/0.13.1/sbt.deb /tmp/
 
 RUN \
+  apt-get update -qq                                                          && \
   apt-get install libjansi-java libjansi-native-java libhawtjni-runtime-java  && \
   dpkg -i /tmp/scala-2.11.5.deb                                               && \
   dpkg -i /tmp/sbt.deb                                                        && \
-  rm -f /tmp/scala-2.11.5.deb /tmp/sbt.deb
+  apt-get clean                                                               && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/builder/scala/scala_2.9.3/Dockerfile
+++ b/builder/scala/scala_2.9.3/Dockerfile
@@ -6,7 +6,9 @@ ADD http://www.scala-lang.org/files/archive/scala-2.9.3.deb /tmp/
 ADD http://repo.scala-sbt.org/scalasbt/sbt-native-packages/org/scala-sbt/sbt/0.13.1/sbt.deb /tmp/
 
 RUN \
+  apt-get update -qq                                                          && \
   apt-get install libjansi-java libjansi-native-java libhawtjni-runtime-java  && \
   dpkg -i /tmp/scala-2.9.3.deb                                                && \
   dpkg -i /tmp/sbt.deb                                                        && \
-  rm -f /tmp/scala-2.9.3.deb /tmp/sbt.deb
+  apt-get clean                                                               && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/builder/scala/scala_2.9.3/Dockerfile
+++ b/builder/scala/scala_2.9.3/Dockerfile
@@ -1,8 +1,6 @@
-FROM sphonic/base:trusty
-MAINTAINER Daniel Malon <operations@sphonic.com>
+FROM sphonic/base-java:20150219
 
-WORKDIR /root
-USER root
+MAINTAINER Daniel Malon <operations@sphonic.com>
 
 ADD http://www.scala-lang.org/files/archive/scala-2.9.3.deb /tmp/
 ADD http://repo.scala-sbt.org/scalasbt/sbt-native-packages/org/scala-sbt/sbt/0.13.1/sbt.deb /tmp/

--- a/cleanup_images
+++ b/cleanup_images
@@ -6,8 +6,14 @@
 source $(dirname $(readlink -f $0))/_functions.sh
 
 # base
-skip "base:precise"
+remove "base:precise"
 remove "base:trusty"
+
+# base-core
+remove "base-core:20150219"
+
+# base-java
+remove "base-java:20150219"
 
 # gcc
 remove "gcc:4.6"

--- a/database/mongodb/mongodb_2.2.7/Dockerfile
+++ b/database/mongodb/mongodb_2.2.7/Dockerfile
@@ -1,4 +1,5 @@
-FROM sphonic/ubuntu:trusty
+FROM ubuntu:trusty
+
 MAINTAINER Daniel Malon <operations@sphonic.com>
 
 WORKDIR /root

--- a/database/mongodb/mongodb_2.4.12/Dockerfile
+++ b/database/mongodb/mongodb_2.4.12/Dockerfile
@@ -1,4 +1,5 @@
-FROM sphonic/ubuntu:trusty
+FROM ubuntu:trusty
+
 MAINTAINER Daniel Malon <operations@sphonic.com>
 
 WORKDIR /root

--- a/database/mongodb/mongodb_2.6.7/Dockerfile
+++ b/database/mongodb/mongodb_2.6.7/Dockerfile
@@ -1,4 +1,5 @@
-FROM sphonic/ubuntu:trusty
+FROM ubuntu:trusty
+
 MAINTAINER Daniel Malon <operations@sphonic.com>
 
 WORKDIR /root

--- a/publish_images
+++ b/publish_images
@@ -6,8 +6,14 @@
 source $(dirname $(readlink -f $0))/_functions.sh
 
 # base
-publish "base:precise"
-publish "base:trusty"
+deprecated "base:precise"
+deprecated "base:trusty"
+
+# base-core
+publish "base-core:20150219"
+
+# base-java
+publish "base-java:20150219"
 
 # gcc
 publish "gcc:4.6"


### PR DESCRIPTION
By splitting out the java bits we can do upgrades to the jdk versions and all dependend images without rolling upgrades for all the other language-sets.

We also deprecate the original base image will build base-core solely from ubuntu:trusty and later.

All builders should extend base-core except clojure/leiningen and scala buildmachines which will extend core-java.

MongoDB buildmachines will extend the official ubuntu:trusty image because we no longer maintain a separate sphonic/ubuntu image.
