### PR TITLE
Add groovy+grails buildmachine images

### DIFF
--- a/build_images
+++ b/build_images
@@ -51,6 +51,9 @@ build "ruby:2.0.0-p598" "builder/ruby/ruby_2.0.0-p598/"
 build "ruby:2.1.5" "builder/ruby/ruby_2.1.5/"
 build "ruby:2.2.0" "builder/ruby/ruby_2.2.0/"
 
+# groovy + grails
+build "grails:2.3.5" "builder/grails/grails_2.3.5/"
+
 # elasticsearch
 build "elasticsearch:0.90.13" "database/elasticsearch/elasticsearch_0.90.13/"
 build "elasticsearch:1.0.3" "database/elasticsearch/elasticsearch_1.0.3/"

--- a/builder/grails/grails_2.3.5/Dockerfile
+++ b/builder/grails/grails_2.3.5/Dockerfile
@@ -1,0 +1,11 @@
+FROM sphonic/base-java:20150219
+
+MAINTAINER Daniel Malon <operations@sphonic.com>
+
+ADD rootfs/etc /etc/
+
+ENV GROOVY_VERSION 2.2.2
+ENV GRAILS_VERSION 2.3.5
+
+ADD scripts /tmp/scripts
+RUN cd /tmp && bash scripts/install.sh && sudo rm -rf /tmp/scripts

--- a/builder/grails/grails_2.3.5/rootfs/etc/drone.d/gvm.sh
+++ b/builder/grails/grails_2.3.5/rootfs/etc/drone.d/gvm.sh
@@ -1,0 +1,21 @@
+# set default env vars
+export GROOVY_VERSION=${GROOVY_VERSION:=""}
+export GRAILS_VERSION=${GRAILS_VERSION:=""}
+
+# load gvmtool if installed
+if [[ -f /root/.gvm/bin/gvm-init.sh ]]; then
+  source /root/.gvm/bin/gvm-init.sh
+
+  # install requested groovy version if necessary
+  if [[ ! -z ${GROOVY_VERSION} ]]; then
+    gvm use groovy ${GROOVY_VERSION}
+  fi
+
+  # install requested grails version if necessary
+  if [[ ! -z ${GRAILS_VERSION} ]]; then
+    gvm use grails ${GRAILS_VERSION}
+  fi
+
+  # flush archives
+  gvm flush archives 1> /dev/null
+fi

--- a/builder/grails/grails_2.3.5/scripts/install.sh
+++ b/builder/grails/grails_2.3.5/scripts/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# install gvmtool
+curl -s get.gvmtool.net | bash
+
+# configure gvmtool to run non-interactive
+mkdir -p /root/.gvm/etc
+cat << EOF > /root/.gvm/etc/config
+gvm_auto_answer=true
+gvm_auto_selfupdate=false
+EOF
+
+# activate default groovy and grails versions
+bash /etc/drone.d/gvm.sh
+
+# exit successfully
+exit 0

--- a/cleanup_images
+++ b/cleanup_images
@@ -51,6 +51,9 @@ remove "ruby:2.0.0-p598"
 remove "ruby:2.1.5"
 remove "ruby:2.2.0"
 
+# groovy + grails
+remove "grails:2.3.5"
+
 # elasticsearch
 remove "elasticsearch:0.90.13"
 remove "elasticsearch:1.0.3"

--- a/publish_images
+++ b/publish_images
@@ -51,6 +51,9 @@ publish "ruby:2.0.0-p598"
 publish "ruby:2.1.5"
 publish "ruby:2.2.0"
 
+# groovy + grails
+publish "grails:2.3.5"
+
 # elasticsearch
 publish "elasticsearch:0.90.13"
 publish "elasticsearch:1.0.3"


### PR DESCRIPTION
These images have groovy and grails versions managed by gvmtool.
The requested version of groovy and grails can be set via ENV variables.
