### PR TITLE
Add nodejs 0.12.0

### DIFF
--- a/build_images
+++ b/build_images
@@ -32,6 +32,7 @@ build "leiningen:2.5.1" "builder/clojure/leiningen_2.5.1/"
 build "nodejs:0.8.26" "builder/nodejs/nodejs_0.8.26/"
 build "nodejs:0.10.36" "builder/nodejs/nodejs_0.10.36/"
 build "nodejs:0.11.14" "builder/nodejs/nodejs_0.11.14/"
+build "nodejs:0.12.0" "builder/nodejs/nodejs_0.12.0/"
 
 # golang
 build "golang:1.2.2" "builder/golang/golang_1.2.2/"

--- a/builder/nodejs/nodejs_0.12.0/Dockerfile
+++ b/builder/nodejs/nodejs_0.12.0/Dockerfile
@@ -1,0 +1,9 @@
+FROM sphonic/base-core:20150219
+
+MAINTAINER Daniel Malon <operations@sphonic.com>
+
+ENV NODENV_VERSION 0.12.0
+
+RUN \
+  git -C .nodenv/plugins/node-build pull && \
+  /bin/bash /etc/drone.d/nodenv.sh

--- a/cleanup_images
+++ b/cleanup_images
@@ -32,6 +32,7 @@ remove "leiningen:2.5.1"
 remove "nodejs:0.8.26"
 remove "nodejs:0.10.36"
 remove "nodejs:0.11.14"
+remove "nodejs:0.12.0"
 
 # golang
 remove "golang:1.2.2"

--- a/publish_images
+++ b/publish_images
@@ -32,6 +32,7 @@ publish "leiningen:2.5.1"
 publish "nodejs:0.8.26"
 publish "nodejs:0.10.36"
 publish "nodejs:0.11.14"
+publish "nodejs:0.12.0"
 
 # golang
 publish "golang:1.2.2"


### PR DESCRIPTION
This also updates the nodenv node-build plugin to get access to the latest 0.12.0 build instructions prior to generating the resulting image.
