### PR TITLE
es.index.store.type=memory not valid in ES 2.2

### DIFF
--- a/database/elasticsearch/elasticsearch_2.2.0/Dockerfile
+++ b/database/elasticsearch/elasticsearch_2.2.0/Dockerfile
@@ -16,6 +16,5 @@ ENTRYPOINT ["/opt/elasticsearch-2.2.0/bin/elasticsearch"]
 CMD [ \
   "-Des.insecure.allow.root=true", \
   "-Des.network.host=0.0.0.0", \
-  "-Des.index.store.type=memory", \
   "-Des.script.inline=true" \
 ]


### PR DESCRIPTION
see https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-store.html
